### PR TITLE
UTF-8 encoding for File.open to extend string handling for characters outside ASCII

### DIFF
--- a/importers/lastpass2pass.rb
+++ b/importers/lastpass2pass.rb
@@ -74,7 +74,7 @@ end
 entries = []
 entry = ""
 begin
-  file = File.open(filename)
+  file = File.open(filename,'r:UTF-8')
   file.each do |line|
     if line =~ /^(http|ftp|ssh)/
       entries.push(entry)


### PR DESCRIPTION
Since LastPass can use unicode characters it's possible that text outside the ASCII range can be in the exported CSV. 

This will allow the file to open with UTF-8 encoding and correctly handle these cases.