### PR TITLE
importers/kwallet2pass.py: s/child.text/str(child.text)/

### DIFF
--- a/importers/kwallet2pass.py
+++ b/importers/kwallet2pass.py
@@ -70,7 +70,7 @@ def import_map(element, path):
     for child in element:
         if child.tag == 'mapentry':
             name = child.attrib['name']
-            text = text + '\n\n' + name + '\n' + child.text
+            text = text + '\n\n' + name + '\n' + str(child.text)
             nEntries += 1
             for child2 in child:
                 unexpected(child, path_for(child, npath))


### PR DESCRIPTION
Importing a kwallet-exported xml file works after "forcing" conversion of child.text to be of type string.