### PR TITLE
Fall back to empty string if None is returned

### DIFF
--- a/importers/keepass2pass.py
+++ b/importers/keepass2pass.py
@@ -39,7 +39,7 @@ def get_value(elements, node_text):
 def path_for(element, path=''):
     """ Generate path name from elements title and current path """
     if element.tag == 'Entry':
-        title = get_value(element.findall("String"), "Title")
+        title = get_value(element.findall("String"), "Title") or ''
     elif element.tag == 'Group':
         title = element.find('Name').text
     else: title = ''


### PR DESCRIPTION
get_value (and element.text) might be None. This doesn't work well for line 49 where str.join expects string parameters.