### PR TITLE
Support for multiline notes in pwsafe

### DIFF
--- a/lib/import.py
+++ b/lib/import.py
@@ -496,10 +496,13 @@ class Pwsafe(PasswordManagerXML):
             'url': 'url', 'comments': 'notes', 'group': 'group'}
 
     def _import(self, element):
+        delimiter = element.attrib['delimiter']
         for xmlentry in element.findall('entry'):
             entry = self._getentry(xmlentry)
             if 'group' in entry:
                 entry['group'] = entry['group'].replace('.', '/')
+            if 'comments' in entry:
+                entry['comments'] = entry['comments'].replace(delimiter, '\n')
             self.data.append(entry)
 
 

--- a/tests/db/pwsafe.xml
+++ b/tests/db/pwsafe.xml
@@ -55,7 +55,7 @@ xsi:noNamespaceSchemaLocation="pwsafe.xsd">
 		<group><![CDATA[CornerCases]]></group>
 		<title><![CDATA[note]]></title>
 		<password><![CDATA[]]></password>
-		<notes><![CDATA[This is a multiline note entry. Cube shank petroleum guacamole dart mower acutely slashing upper cringing lunchbox tapioca wrongful unbeaten sift.]]></notes>
+		<notes><![CDATA[This is a multiline note entry. Cube shank petroleum guacamole dart mower»acutely slashing upper cringing lunchbox tapioca wrongful unbeaten sift.]]></notes>
 		<uuid><![CDATA[c3053566d75946d04755d8caac43680c]]></uuid>
 		<rmtimex>2017-11-18T19:35:36</rmtimex>
 	</entry>


### PR DESCRIPTION
Hi Alex.

Thank you very much for the import extension.

Password Safe allows multi line notes.
When exporting to XML newlines in the notes field are encoded as » by default. The selected value is saved as a property "delimiter" on the root passwordsafe element.

I used the newest windows version of Password Safe for my test, ie 3.45.