### PR TITLE
Support for importing email address from Password Safe

### DIFF
--- a/lib/import.py
+++ b/lib/import.py
@@ -179,7 +179,7 @@ class PasswordManager():
     Please read CONTRIBUTING.md for more details regarding data structure
     in pass-import.
     """
-    keyslist = ['title', 'password', 'login', 'url', 'email', 'comments', 'group']
+    keyslist = ['title', 'password', 'login', 'url', 'comments', 'group']
 
     def __init__(self, extra=False):
         self.data = []
@@ -369,12 +369,11 @@ class Enpass(PasswordManagerCSV):
             entry['title'] = row.pop(0)
             comments = row.pop()
             for key in self.keyslist:
-                if key in self.keys:
-                    csvkey = self.keys[key]
-                    if csvkey in row:
-                        index = row.index(csvkey)
-                        entry[key] = row.pop(index+1)
-                        row.pop(index)
+                csvkey = self.keys[key]
+                if csvkey in row:
+                    index = row.index(csvkey)
+                    entry[key] = row.pop(index+1)
+                    row.pop(index)
             entry['comments'] = comments
 
             if self.all:
@@ -493,6 +492,7 @@ class PasswordExporter(PasswordManagerCSV):
 
 class Pwsafe(PasswordManagerXML):
     format = 'passwordsafe'
+    keyslist = ['title', 'password', 'login', 'url', 'email', 'comments', 'group']
     keys = {'title': 'title', 'password': 'password', 'login': 'username',
             'url': 'url', 'email': 'email', 'comments': 'notes', 'group': 'group'}
 

--- a/lib/import.py
+++ b/lib/import.py
@@ -179,7 +179,7 @@ class PasswordManager():
     Please read CONTRIBUTING.md for more details regarding data structure
     in pass-import.
     """
-    keyslist = ['title', 'password', 'login', 'url', 'comments', 'group']
+    keyslist = ['title', 'password', 'login', 'url', 'email', 'comments', 'group']
 
     def __init__(self, extra=False):
         self.data = []
@@ -369,11 +369,12 @@ class Enpass(PasswordManagerCSV):
             entry['title'] = row.pop(0)
             comments = row.pop()
             for key in self.keyslist:
-                csvkey = self.keys[key]
-                if csvkey in row:
-                    index = row.index(csvkey)
-                    entry[key] = row.pop(index+1)
-                    row.pop(index)
+                if key in self.keys:
+                    csvkey = self.keys[key]
+                    if csvkey in row:
+                        index = row.index(csvkey)
+                        entry[key] = row.pop(index+1)
+                        row.pop(index)
             entry['comments'] = comments
 
             if self.all:
@@ -493,7 +494,7 @@ class PasswordExporter(PasswordManagerCSV):
 class Pwsafe(PasswordManagerXML):
     format = 'passwordsafe'
     keys = {'title': 'title', 'password': 'password', 'login': 'username',
-            'url': 'url', 'comments': 'notes', 'group': 'group'}
+            'url': 'url', 'email': 'email', 'comments': 'notes', 'group': 'group'}
 
     def _import(self, element):
         delimiter = element.attrib['delimiter']

--- a/tests/db/pwsafe.xml
+++ b/tests/db/pwsafe.xml
@@ -77,6 +77,7 @@ xsi:noNamespaceSchemaLocation="pwsafe.xsd">
 				</history_entry>
 			</history_entries>
 		</pwhistory>
+		<email><![CDATA[someuser@example.com]]></email>
 	</entry>
 
 	<entry id="5">


### PR DESCRIPTION
Hi again.

One of the standard fields in Password Safe is E-mail.

I took the easy route and added 'email' to `keyslist`. That way the E-mail address is placed before the comments in the result.

Alternatively I can make it an --extra item for pwsafe (like password history).

Please let me know if you want me to change the PR.

Best regards,
Søren Thing