### PR TITLE
Save items from an export with no group in a group named 'untitled'

### DIFF
--- a/lib/import.py
+++ b/lib/import.py
@@ -500,7 +500,7 @@ class KeepassX(PasswordManagerXML):
     def _getpath(cls, element, path=''):
         res = ''
         if element.tag != 'database':
-	    if element.find('title').text:
+            if element.find('title').text:
                 res = os.path.join(path, element.find('title').text)
             else:
                 res = os.path.join(path, 'untitled')

--- a/lib/import.py
+++ b/lib/import.py
@@ -500,7 +500,10 @@ class KeepassX(PasswordManagerXML):
     def _getpath(cls, element, path=''):
         res = ''
         if element.tag != 'database':
-            res = os.path.join(path, element.find('title').text)
+	    if element.find('title').text:
+                res = os.path.join(path, element.find('title').text)
+            else:
+                res = os.path.join(path, 'untitled')
         return res
 
     def _import(self, element, path=''):


### PR DESCRIPTION
This solves the issue #47 
If element.find('title').text was empty from the export the import failed.

This PR makes it save it in a pass "folder" called untitled instead. 