### PR TITLE
Add TOTP secret extraction (full support for KeePassXML)

### DIFF
--- a/pass_import.py
+++ b/pass_import.py
@@ -244,7 +244,9 @@ class PasswordManager():
             if key == 'otpauth':
                 secret_match = re.search(r'^([a-zA-Z2-7]{16,32})=*$', value)
                 if secret_match is None:
-                    raise PasswordStoreError('OTP secret not found. Must be in base32 and between 16 and 32 characters')
+                    raise PasswordStoreError('OTP secret not found.'
+                                             'Must be in base32 and between '
+                                             '16 and 32 characters')
                 else:
                     value = secret_match.group(1)
                 string += "%s://totp/totp-secret?secret=%s&issuer=totp-secret\n" % (key, value)


### PR DESCRIPTION
Hi !

This is my very first PR, I hope I am doing it well. Thank you for this pass' plugin.
Extra fields option must be set to True for this to work.

To include support for other password managers, 'otpauth' must be include in keys of the manager with value corresponding with field in imported file. I didn't do it as I don't know the name of otp field in file produced by other password manager than KeePass but it should be easy.

Commit description :
- Add 'otpauth' field in PasswordManager keyslist
- Add URI output for 'otpauth' field in PasswordManager class in get method :
    - Secret is extracted with regex r'^([a-zA-Z2-7]{16,32})=*$' . So it must be between 16 and 32 characters in base32.
    - Raise PasswordStoreError if OTP extraction failed
- Only TOTP are supported 
- 'otpauth' added in KeePass manager keys dictionnary. The field 'otp' must contain the secret.