### PR TITLE
Makefile: Fix local install on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ PASSWORD_STORE_EXTENSIONS_DIR ?= $(PASSWORD_STORE_DIR)/.extensions
 local:
 	@install -v -d "$(DESTDIR)$(PASSWORD_STORE_EXTENSIONS_DIR)/"
 	@install -v -m 0755 "$(PROG).bash" "$(DESTDIR)$(PASSWORD_STORE_EXTENSIONS_DIR)/$(PROG).bash"
-	@python3 setup.py install --user --optimize=1
+	@python3 setup.py install --user --prefix= --optimize=1
 	@echo
 	@echo "pass-$(PROG) is localy installed succesfully."
 	@echo "Warning, because it is a local installation, there is no manual page or shell completion."


### PR DESCRIPTION
On macOS Python 3 is not installed by default and must be installed
using a third-party package manager. When installed using the Brew
package manager, Python 3 gets a system-wide distutils.cfg at:

	/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/distutils.cfg

Which sets prefix=/usr/local and breaks the --user flag:

	$ python3 setup.py install --user --optimize=1
	running install
	error: can't combine user with prefix, exec_prefix/home, or install_(plat)base

We can work around this by always forcing the prefix to be blank [0].

[0] https://stackoverflow.com/a/4495175/2203114