### PR TITLE
add in encryptr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Pass import handles duplicates and is compatible with [browserpass][bp].
 | [buttercup][buttercup] | *File > Export > Export File to CSV* | `pass import buttercup file.csv` |
 | [chrome][chrome] | *See this [guide][export-chrome]* | `pass import chrome file.csv` |
 | [chromesqlite][chrome] | *See this [guide][export-chrome]* | `pass import chrome file.csv` |
+| [encryptr][encryptr] | *See this [encryptr issue](https://github.com/SpiderOak/Encryptr/issues/295#issuecomment-322449705)* | `pass import encryptr file.csv` |
 | [enpass][enpass] | *File > Export > As CSV* | `pass import enpass file.csv` |
 | [enpass6][enpass] | *Menu > File > Export > As JSON* | `pass import enpass6 file.json` |
 | [dashlane][dashlane] | *File > Export > Unsecured Archive in CSV* | `pass import dashlane file.csv` |
@@ -271,6 +272,7 @@ Feedback, contributors, pull requests are all very welcome. Please read the
 [buttercup]: https://buttercup.pw/
 [chrome]: https://support.google.com/chrome
 [dashlane]: https://www.dashlane.com/
+[encryptr]: https://spideroak.com/encryptr/
 [enpass]: https://www.enpass.io/
 [fpm]: http://fpm.sourceforge.net/
 [gorilla]: https://github.com/zdia/gorilla/wiki

--- a/pass-import.1
+++ b/pass-import.1
@@ -197,6 +197,16 @@ Export: File > Export > Unsecured Archive in CSV
 Command: pass import dashlane file.csv
 
 .TP
+\fBencryptr\fP
+Website: \fIhttps://spideroak.com/encryptr/\fP
+
+Export: Compile from source and follow instructions here:
+
+\fIhttps://github.com/SpiderOak/Encryptr/issues/295#issuecomment-322449705\fP
+
+Command: pass import encryptr file.csv
+
+.TP
 \fBenpass\fP
 Website: \fIhttps://www-enpass.io/\fP
 

--- a/pass_import.py
+++ b/pass_import.py
@@ -756,11 +756,6 @@ class Encryptr(PasswordManagerCSV):
     # "Text", "Type", "Name on card", "Card Number", "CVV", "Expiry"
 
     # and now let's map it all. Ignoring Entry Type.
-    keyslist = [
-        'title', 'password', 'login', 'url', 'comments', 'text',
-        'card-type', 'card-name-on-card', 'card-number', 'card-cvv',
-        'card-expiry'
-    ]
     keys = {
         'title': 'Label',
         'password': 'Password',
@@ -770,17 +765,14 @@ class Encryptr(PasswordManagerCSV):
         'text': 'Text',  # do we want to consider this
                          # a password since it was the
                          # "secret" for general type?
-        'card-type': "Type",
-        'card-name-on-card': "Name on card",
-        'card-number': "Card Number",
-        'card-cvv': "CVV",
-        'card-expiry': "Expiry"
+        'group': 'Entry Type',
     }
 
     # since it's dynamically generated, there is no guarantee
     # that all keys are there (e.g, no credit cards, no keys related to it.)
     # so we only check for those that are there with at least one entry.
-    def _checkformat(self, fieldnames):
+    @classmethod
+    def _checkformat(cls, fieldnames):
         for csvkey in ("Entry Type", "Label", "Notes"):
             if csvkey not in fieldnames:
                 raise FormatError()

--- a/tests/db/card/encryptr.csv
+++ b/tests/db/card/encryptr.csv
@@ -1,0 +1,2 @@
+Entry Type,Label,Password,Username,Site URL,Notes,Text,Type,Name on card,Card Number,CVV,Expiry
+Credit Card,Goliath National Bank,,,,note here,,Visatron,J Smith,5012345678900000,123,22/01

--- a/tests/db/encryptr.csv
+++ b/tests/db/encryptr.csv
@@ -1,0 +1,16 @@
+Entry Type,Label,Password,Username,Site URL,Notes,Text,Type,Name on card,Card Number,CVV,Expiry
+Password,mastodon.social,D<INNeT?#?Bf4%`zA/4i!/'$T,ostqxi,mastodon.social/,,,,,,,
+Password,twitter.com,"SoNEwvU,kJ%-cIKJ9[c#S;]jB",ostqxi,twitter.com/,,,,,,,
+Password,news.ycombinator.com,"1)Btf2EI~Tfb7g2A!Sy',*Sj#",ostqxi,news.ycombinator.com,,,,,,,
+Password,ovh.com,^Vr/|o>_H8X%T]7>f}7|:U!Zs,jsdkyvbwjn,www.ovh.com/manager/web/,,,,,,,
+Password,ovh.com,"3Z-VW!i,j(&!zRGPu(hFe]s'(",bynbyjhqjz,www.ovh.com/manager/web/,,,,,,,
+Password,aib,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",dpbx@fner.ws,onlinebanking.aib.ie,462916,,,,,,
+Password,dpbx@afoqwdr.tx,9KVHnx:.S_S;cF`=CE@e\p{v6,dpbx,afoqwdr.tx,,,,,,,
+Password,dpbx@klivak.xb,"2cUqe}e9}>IVZf)Ye>3C8ZN,r",dpbx,,This is a garbage address,,,,,,
+Password,dpbx@mnyfymt.ws,rPCkmNkhIa>{izt3C3F823!Go,dpbx,mail.mnyfymt.ws,,,,,,,
+Password,dpbx@fner.ws,mt}h'hSUCY;SU;;A!l[8y3O:8,dpbx,,For financial purpose only!,,,,,,
+Password,space title,]stDKo{%pk,vkeelpbu,nhysdo.wg,,,,,,,
+Password,empty entry,,,,,,,,,,
+Password,empty password,,vkeelpbu,nhysdo.wg,,,,,,,
+General,note,,,,,"This is a multiline note entry. Cube shank petroleum guacamole dart mower
+acutely slashing upper cringing lunchbox tapioca wrongful unbeaten sift.",,,,,

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -70,12 +70,14 @@ REF_WIFI = [Odict([('title', 'android'),
                    ('password', 'X3<yS1g9wW-@lC87pekRmXMJp')])]
 
 REF_CARD = [
-    Odict([('title', "Goliath National Bank"),
-           ('Type', "Visatron"),
-           ('Name on card', "J Smith"),
-           ('Card Number', "5012345678900000"),
-           ('CVV', "123"),
-           ('Expiry', "22/01")]),
+    {
+        'title': "Goliath National Bank",
+        'Type': "Visatron",
+        'Name on card': "J Smith",
+        'Card Number': "5012345678900000",
+        'CVV': "123",
+        'Expiry': "22/01"
+    }
 ]
 
 

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -71,11 +71,11 @@ REF_WIFI = [Odict([('title', 'android'),
 
 REF_CARD = [
     Odict([('title', "Goliath National Bank"),
-           ('card-type', "Visatron"),
-           ('card-name-on-card', "J Smith"),
-           ('card-number', "5012345678900000"),
-           ('card-cvv', "123"),
-           ('card-expiry', "22/01")]),
+           ('Type', "Visatron"),
+           ('Name on card', "J Smith"),
+           ('Card Number', "5012345678900000"),
+           ('CVV', "123"),
+           ('Expiry', "22/01")]),
 ]
 
 
@@ -128,12 +128,11 @@ class TestBaseImporters(TestBase):
 
 
 class TestImporters(TestBaseImporters):
-    CARD_IMPORTERS = ['encryptr',]
 
     def test_importers(self):
         """Testing: importer parse method using real data."""
         keys = ['title', 'password', 'login', 'ssid']
-        ignore = ['networkmanager', 'card']
+        ignore = ['networkmanager']
         for manager in pass_import.importers:
             if manager in ignore:
                 continue
@@ -154,9 +153,10 @@ class TestImporters(TestBaseImporters):
         self.assertImport(keys, importer.data, REF_WIFI)
 
     def test_importers_card(self):
-        keys = ['title', 'card-type', 'card-name-on-card',
-                'card-number', 'card-cvv', 'card-expiry']
-        for manager in self.CARD_IMPORTERS:
+        card_managers = ['encryptr',]
+        keys = ['title', 'Type', 'Name on card',
+                'Card Number', 'CVV', 'Expiry']
+        for manager in card_managers:
             with self.subTest(manager):
                 importer = self._class(manager)
                 # however, it's in a different folder

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -154,14 +154,14 @@ class TestImporters(TestBaseImporters):
         self.assertImport(keys, importer.data, REF_WIFI)
 
     def test_importers_card(self):
-        keys = ['title', 'card-type', 'card-name-on-card', 'card-number', 'card-cvv', 'card-expiry']
-        testpath = os.path.join(self.db, 'card')
+        keys = ['title', 'card-type', 'card-name-on-card',
+                'card-number', 'card-cvv', 'card-expiry']
         for manager in self.CARD_IMPORTERS:
             with self.subTest(manager):
                 importer = self._class(manager)
                 # however, it's in a different folder
                 test_filename, encoding = self._path(manager, folder="card")
-                with open(test_filename, 'r', encoding='utf-8') as file:
+                with open(test_filename, 'r', encoding=encoding) as file:
                     importer.parse(file)
                 self.assertImport(keys, importer.data, REF_CARD)
 


### PR DESCRIPTION
Adds in support for encryptr csv exports (which is not easy to get out of encryptr, so [for visibility](https://github.com/SpiderOak/Encryptr/issues/295#issuecomment-322449705))

I haven't * actually * tested credit card support end-to-end as i've never put cards in to encryptr, but every indicator says this should work.

My only code concern is that the tests for cards and passwords are totally separate/isolated - I have not tested importing both together, and the way the tests are structured this would be difficult. If you have advice on this, I'm all ears.

Thanks