### PR TITLE
better entry name deduplication

### DIFF
--- a/pass_import.py
+++ b/pass_import.py
@@ -585,7 +585,7 @@ class PasswordManager():
                                                                     '')))
             entry['path'] = self._create_path(entry, path, clean, convert)
 
-        for i in range(2):
+        for _ in range(2):
             self._duplicate_paths(clean, convert)
         self._duplicate_numerise()
 

--- a/pass_import.py
+++ b/pass_import.py
@@ -530,13 +530,17 @@ class PasswordManager():
         title = ''
         for key in ['title', 'host', 'url', 'login']:
             if key in entry and entry[key]:
-                title = self._clean_protocol(entry[key])
-                for component in title.split(os.sep):
-                    if component == '':
-                        continue
-                    else:
-                        title = component
-                        break
+                title = entry[key]
+                if key in ['title', 'host', 'url']:
+                    title = self._clean_protocol(title)
+                    # Only use hostname part of (potential) URLs
+                    if key in ['host', 'url']:
+                        for component in title.split('/'):
+                            if component == '':
+                                continue
+                            else:
+                                title = component
+                                break
                 title = self._clean_title(title)
                 if clean:
                     title = self._clean_cmdline(title)

--- a/pass_import.py
+++ b/pass_import.py
@@ -528,16 +528,24 @@ class PasswordManager():
     def _create_path(self, entry, path, clean, convert):
         """Create path from title and group."""
         title = ''
-        for key in ['title', 'login', 'url']:
-            if key in entry:
+        for key in ['title', 'host', 'url', 'login']:
+            if key in entry and entry[key]:
                 title = self._clean_protocol(entry[key])
+                for component in title.split(os.sep):
+                    if component == '':
+                        continue
+                    else:
+                        title = component
+                        break
                 title = self._clean_title(title)
                 if clean:
                     title = self._clean_cmdline(title)
                 if convert:
                     title = self._convert(title)
-                path = os.path.join(path, title)
-                break
+                if title != '':
+                    if os.path.basename(path) != title:
+                        path = os.path.join(path, title)
+                        break
 
         if title == '':
             path = os.path.join(path, 'notitle')
@@ -573,7 +581,8 @@ class PasswordManager():
                                                                     '')))
             entry['path'] = self._create_path(entry, path, clean, convert)
 
-        self._duplicate_paths(clean, convert)
+        for i in range(2):
+            self._duplicate_paths(clean, convert)
         self._duplicate_numerise()
 
 

--- a/pass_import.py
+++ b/pass_import.py
@@ -551,7 +551,7 @@ class PasswordManager():
                         path = os.path.join(path, title)
                         break
 
-        if title == '':
+        if title == '' and os.path.basename(path) != 'notitle':
             path = os.path.join(path, 'notitle')
         entry.pop('title', '')
         return path

--- a/tests/db/revelation.xml
+++ b/tests/db/revelation.xml
@@ -67,6 +67,53 @@ acutely slashing upper cringing lunchbox tapioca wrongful unbeaten sift.</notes>
 	</entry>
 
 	<entry type="folder">
+		<name>Duplicate Entries</name>
+		<description></description>
+		<updated>1558691994</updated>
+		<notes></notes>
+
+		<entry type="generic">
+			<name>CMS</name>
+			<description></description>
+			<updated>1558693003</updated>
+			<notes></notes>
+			<field id="generic-hostname">foo.example.org</field>
+			<field id="generic-username">user</field>
+			<field id="generic-password">XmW9b7J7jv</field>
+		</entry>
+
+		<entry type="generic">
+			<name>CMS</name>
+			<description></description>
+			<updated>1558693031</updated>
+			<notes></notes>
+			<field id="generic-hostname">foo.example.org</field>
+			<field id="generic-username">admin</field>
+			<field id="generic-password">4wfd9TvEZ2</field>
+		</entry>
+
+		<entry type="generic">
+			<name>CMS</name>
+			<description></description>
+			<updated>1558693058</updated>
+			<notes></notes>
+			<field id="generic-hostname">bar.example.org</field>
+			<field id="generic-username">user</field>
+			<field id="generic-password">D9ahtXk6bz</field>
+		</entry>
+
+		<entry type="generic">
+			<name>CMS</name>
+			<description></description>
+			<updated>1558693085</updated>
+			<notes></notes>
+			<field id="generic-hostname">bar.example.org</field>
+			<field id="generic-username">admin</field>
+			<field id="generic-password">oN3ARkN7hR</field>
+		</entry>
+	</entry>
+
+	<entry type="folder">
 		<name>Emails</name>
 		<description></description>
 		<updated>1511034723</updated>

--- a/tests/db/revelation.xml
+++ b/tests/db/revelation.xml
@@ -67,53 +67,6 @@ acutely slashing upper cringing lunchbox tapioca wrongful unbeaten sift.</notes>
 	</entry>
 
 	<entry type="folder">
-		<name>Duplicate Entries</name>
-		<description></description>
-		<updated>1558691994</updated>
-		<notes></notes>
-
-		<entry type="generic">
-			<name>CMS</name>
-			<description></description>
-			<updated>1558693003</updated>
-			<notes></notes>
-			<field id="generic-hostname">foo.example.org</field>
-			<field id="generic-username">user</field>
-			<field id="generic-password">XmW9b7J7jv</field>
-		</entry>
-
-		<entry type="generic">
-			<name>CMS</name>
-			<description></description>
-			<updated>1558693031</updated>
-			<notes></notes>
-			<field id="generic-hostname">foo.example.org</field>
-			<field id="generic-username">admin</field>
-			<field id="generic-password">4wfd9TvEZ2</field>
-		</entry>
-
-		<entry type="generic">
-			<name>CMS</name>
-			<description></description>
-			<updated>1558693058</updated>
-			<notes></notes>
-			<field id="generic-hostname">bar.example.org</field>
-			<field id="generic-username">user</field>
-			<field id="generic-password">D9ahtXk6bz</field>
-		</entry>
-
-		<entry type="generic">
-			<name>CMS</name>
-			<description></description>
-			<updated>1558693085</updated>
-			<notes></notes>
-			<field id="generic-hostname">bar.example.org</field>
-			<field id="generic-username">admin</field>
-			<field id="generic-password">oN3ARkN7hR</field>
-		</entry>
-	</entry>
-
-	<entry type="folder">
 		<name>Emails</name>
 		<description></description>
 		<updated>1511034723</updated>

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -154,7 +154,7 @@ class TestPasswordManagerClean(TestPasswordManager):
         data_expected = [{'password': 'UuQHzvv6IHRIJGjwKru7',
                           'login': 'lnqYm3ZWtm',
                           'url': 'twitter.com',
-                          'path': 'lnqYm3ZWtm'}]
+                          'path': 'twitter.com'}]
         self.importer.clean(clean=False, convert=False)
         self.assertEqual(self.importer.data, data_expected)
 
@@ -261,6 +261,43 @@ class TestPasswordManagerDuplicate(TestPasswordManager):
                           'path': 'Emails/google.com/fmmh@gmail.com'},
                          {'login': 'ptfz@gmail.com',
                           'path': 'Emails/google.com/ptfz@gmail.com'}]
+        self.importer.clean(clean=False, convert=False)
+        self.assertEqual(self.importer.data, data_expected)
+
+    def test_two_subfolders(self):
+        """Testing: duplicate to two levels of subfolders."""
+        self.importer.data = [{'title': 'CMS',
+                               'login': 'user',
+                               'host': 'foo.example.org',
+                               'password': 'XmW9b7J7jv'},
+                              {'title': 'CMS',
+                               'login': 'admin',
+                               'host': 'foo.example.org',
+                               'password': '4wfd9TvEZ2'},
+                              {'title': 'CMS',
+                               'login': 'user',
+                               'host': 'bar.example.org',
+                               'password': 'D9ahtXk6bz'},
+                              {'title': 'CMS',
+                               'login': 'admin',
+                               'host': 'bar.example.org',
+                               'password': 'oN3ARkN7hR'}]
+        data_expected = [{'path': 'CMS/foo.example.org/user',
+                          'login': 'user',
+                          'host': 'foo.example.org',
+                          'password': 'XmW9b7J7jv'},
+                         {'path': 'CMS/foo.example.org/admin',
+                          'login': 'admin',
+                          'host': 'foo.example.org',
+                          'password': '4wfd9TvEZ2'},
+                         {'path': 'CMS/bar.example.org/user',
+                          'login': 'user',
+                          'host': 'bar.example.org',
+                          'password': 'D9ahtXk6bz'},
+                         {'path': 'CMS/bar.example.org/admin',
+                          'login': 'admin',
+                          'host': 'bar.example.org',
+                          'password': 'oN3ARkN7hR'}]
         self.importer.clean(clean=False, convert=False)
         self.assertEqual(self.importer.data, data_expected)
 


### PR DESCRIPTION
This change improves pass-import's attemps at renaming duplicate entries to disambiguate them:
- Besides 'url', 'host' is also used to build path name
- Only up to the OS path separator of an URL is used as path component
- A new component is only added to the path if it differs from the previous (e.g. if 'title' is already set to 'host' or the hostname part of an URL)
- Two rounds of _duplicate_paths() handling are performed (the number of rounds could be made a commandline/config option, but the typical case of having either 'host' or 'url', plus 'login' to disambiguate makes 2 a pretty good default)

Relevant "Passwords imported" output when importing test data before this change:
```
       Duplicate Entries/CMS/admin
       Duplicate Entries/CMS/admin-1
       Duplicate Entries/CMS/user
       Duplicate Entries/CMS/user-1
       Servers/ovh.com/bynbyjhqjz
       Servers/ovh.com/jsdkyvbwjn
```
And after this change:
```
       Duplicate Entries/CMS/bar.example.org/admin
       Duplicate Entries/CMS/bar.example.org/user
       Duplicate Entries/CMS/foo.example.org/admin
       Duplicate Entries/CMS/foo.example.org/user
       Servers/ovh.com/www.ovh.com/bynbyjhqjz
       Servers/ovh.com/www.ovh.com/jsdkyvbwjn
```
Improvement with the added "Duplicate Entries" test data is obvious, for the existing test data in the "Servers" directory, it adds a level that is not strictly needed, but that is not only easier to fix after importing wyth a simple mv than renaming dozens of foo-N entries, it also allows to add future entires using identical users on different hosts.
Its not perfect, but an improvement that works for me(TM) on my real world Revelation data.