### PR TITLE
don't interpret password names as flags

### DIFF
--- a/pass_import.py
+++ b/pass_import.py
@@ -266,7 +266,7 @@ class PasswordStore():
             if os.path.isfile(os.path.join(self.prefix, path + '.gpg')):
                 raise PasswordStoreError("An entry already exists for %s."
                                          % path)
-        arg = ['insert', '--multiline', '--force']
+        arg = ['insert', '--multiline', '--force', '--']
         arg.append(path)
         return self._pass(arg, data)
 


### PR DESCRIPTION
When importing wifi passwords it might happen that filenames start with dash
due to escaping. This is interpreted by pass's flag parsing.