### PR TITLE
Support for python-magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,17 @@ dist: xenial
 language: python
 cache: pip
 
-jobs:
-  include:
-    - python: 3.8
-    - python: 3.7
-    - python: 3.6
+python:
+  - 3.8
+  - 3.7
+  - 3.6
 
 env:
   global:
     - PASS_VERSION=1.7.3
+  jobs:
+    - TEST_MAGIC=file-magic
+    - TEST_MAGIC=python-magic
 
 addons:
   apt:
@@ -26,7 +28,7 @@ install:
   - make --directory=password-store-$PASS_VERSION install
   - mkdir -p ~/.local/share/keyrings/
   - cp tests/assets/db/gnome-keyring.keyring ~/.local/share/keyrings/pass-import.keyring
-  - pip3 install green coverage codacy-coverage pyaml defusedxml cryptography pykeepass secretstorage file-magic
+  - pip3 install green coverage codacy-coverage pyaml defusedxml cryptography pykeepass secretstorage $TEST_MAGIC
 
 script:
   - dbus-run-session -- make tests

--- a/pass_import/tools.py
+++ b/pass_import/tools.py
@@ -9,7 +9,7 @@ import sys
 
 try:
     import magic
-    MAGIC = hasattr(magic, 'open')
+    MAGIC = True
 except ImportError:
     MAGIC = False
 
@@ -40,20 +40,26 @@ def get_magics(path):
     with open(path, 'rb') as file:
         header = file.read(2048)
 
-    res = magic.detect_from_content(header)
+    if hasattr(magic, 'detect_from_content'):
+        res = magic.detect_from_content(header)
+        mime_type = res.mime_type
+        magic_name = res.name
+    else:
+        return None, None
+
     mime_to_format = {
         'application/pgp': 'gpg',
         'application/x-sqlite3': 'sqlite3'
     }
     name_to_format = {'KDBX': 'kdbx', 'openssl': 'openssl', 'PGP': 'gpg'}
 
-    frmt = mime_to_format.get(res.mime_type, None)
+    frmt = mime_to_format.get(mime_type, None)
     for name in name_to_format:
-        if name in res.name:
+        if name in magic_name:
             frmt = name_to_format[name]
 
     encoding = None  # res.encoding
-    if 'UTF-8 Unicode (with BOM)' in res.name:
+    if 'UTF-8 Unicode (with BOM)' in magic_name:
         encoding = 'utf-8-sig'
 
     return frmt, encoding

--- a/pass_import/tools.py
+++ b/pass_import/tools.py
@@ -44,6 +44,9 @@ def get_magics(path):
         res = magic.detect_from_content(header)
         mime_type = res.mime_type
         magic_name = res.name
+    elif hasattr(magic, 'from_buffer'):
+        mime_type = magic.from_buffer(header, mime=True)
+        magic_name = magic.from_buffer(header)
     else:
         return None, None
 


### PR DESCRIPTION
This is for supporting python-magic as well as file-magic.

Since most distro ships python-magic instead file-magic and I would like to not conflict with other packages.

The CI is failing in `pykeepass` test, but I've try pushed latest master, and the CI also failed.

I don't know if it's related to `pykeepass` update on 2020-07-19?