### PR TITLE
Fix default local installation path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ with open('README.md') as file:
 share = Path(sys.prefix, 'share')
 lib = Path('/usr', 'lib', 'password-store', 'extensions')
 if '--user' in sys.argv:
-    lib = Path.home() / '.password-store' / 'extensions'
+    if 'PASSWORD_STORE_EXTENSIONS_DIR' in os.environ:
+        lib = Path(os.environ['PASSWORD_STORE_EXTENSIONS_DIR'])
+    else:
+        lib = Path.home() / '.password-store' / '.extensions'
     if 'XDG_DATA_HOME' in os.environ:
         share = Path(os.environ['XDG_DATA_HOME'])
     else:


### PR DESCRIPTION
Since the installation is managed by the `setup.py` script, line 21 of the script was setting `lib` to `$HOME/.password-store/extensions` but the default path `pass` searches for is `$HOME/.password-store/.extensions` unless the env variable `PASSWORD_STORE_EXTENSIONS_DIR` is set.