### PR TITLE
add gopass support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ database to a generic CSV file...
       <td align="center"><code>pass import gnome-authenticator file.json</code></td>
     </tr>
     <tr>
+      <td align="center" rowspan="1"><a href="https://www.gopass.pw/">gopass</a></td>
+      <td align="center"><code>pass</code></td>
+      <td align="center"><i>Nothing to do</i></td>
+      <td align="center"><code>pass import gopass path/to/store</code></td>
+    </tr>
+    <tr>
       <td align="center" rowspan="1"><a href="https://github.com/zdia/gorilla/wiki">gorilla</a></td>
       <td align="center"><code>csv</code></td>
       <td align="center"><i>File > Export: Yes: CSV Files</i></td>

--- a/pass_import/managers/__init__.py
+++ b/pass_import/managers/__init__.py
@@ -31,6 +31,7 @@ from pass_import.managers.passman import PassmanCSV, PassmanJSON
 from pass_import.managers.passpack import Passpack
 from pass_import.managers.passpie import Passpie
 from pass_import.managers.passwordstore import PasswordStore
+from pass_import.managers.gopass import Gopass
 from pass_import.managers.pwsafe import Pwsafe
 from pass_import.managers.revelation import Revelation
 from pass_import.managers.roboform import Roboform

--- a/pass_import/managers/gopass.py
+++ b/pass_import/managers/gopass.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+# pass import - Passwords importer swiss army knife
+# Copyright (C) 2017-2020 Alexandre PUJOL <alexandre@pujol.io>.
+#
+
+from pass_import.core import Cap, register_detecters, register_managers
+from pass_import.managers import PasswordStore
+
+
+class Gopass(PasswordStore):
+    """Importer & Exporter for gopass.
+
+    If ``prefix`` is not specified in the constructor, the environment variable
+    ``PASSWORD_STORE_DIR`` is required. The constructor will raise an exception
+    if it is not present.
+
+    This class supports all the environment variables supported by ''pass'',
+    including ``GNUPGHOME``.
+
+    :param dict env: Environment variables used by ``pass``.
+
+    """
+    cap = Cap.FORMAT | Cap.IMPORT | Cap.EXPORT
+    name = 'gopass'
+    format = 'gopass'
+    command = 'gopass'
+    url = 'https://www.gopass.pw/'
+    himport = 'gopass import pass path/to/store'
+
+
+register_managers(Gopass)
+register_detecters(Gopass)

--- a/pass_import/managers/passwordstore.py
+++ b/pass_import/managers/passwordstore.py
@@ -55,7 +55,7 @@ class PasswordStore(CLI, Formatter):
         if prefix:
             self.prefix = prefix
         if 'PASSWORD_STORE_DIR' not in self.env or self.prefix is None:
-            raise PMError("pass prefix unknown")
+            raise PMError("{} prefix unknown".format(self.name))
 
     @property
     def prefix(self):


### PR DESCRIPTION
This is probably the most simple solution for a gopass provider. It inherits from the existing `pass` manager while adjusting only the class parameters.