### PR TITLE
Add KeePass(XC) reference substitution

### DIFF
--- a/pass_import/formats/kdbx.py
+++ b/pass_import/formats/kdbx.py
@@ -56,8 +56,13 @@ class KDBX(Formatter, PasswordImporter, PasswordExporter):
         keys = self.invkeys()
         for attr in self.attributes:
             if hasattr(kpentry, attr):
-                entry[keys.get(attr, attr)] = getattr(kpentry, attr)
+                value = getattr(kpentry, attr)
+                if isinstance(value, str):
+                    value = self._subref(value)
+                entry[keys.get(attr, attr)] = value
         for key, value in kpentry.custom_properties.items():
+            if isinstance(value, str):
+                value = self._subref(value)
             entry[key] = value
         return entry
 

--- a/pass_import/formats/kdbx.py
+++ b/pass_import/formats/kdbx.py
@@ -4,6 +4,8 @@
 #
 
 import os
+import re
+import uuid
 
 try:
     from pykeepass import PyKeePass
@@ -38,6 +40,7 @@ class KDBX(Formatter, PasswordImporter, PasswordExporter):
         'title', 'username', 'password', 'url', 'notes', 'icon', 'tags',
         'autotype_enabled', 'autotype_sequence', 'path', 'is_a_history_entry'
     }
+    reference = re.compile('\{REF:([A-Z])@I:([0-9A-F]{32})\}')
 
     def __init__(self, prefix=None, settings=None):
         self.keepass = None
@@ -57,6 +60,27 @@ class KDBX(Formatter, PasswordImporter, PasswordExporter):
         for key, value in kpentry.custom_properties.items():
             entry[key] = value
         return entry
+
+    def _subref(self, value):
+        while True:
+            match = self.reference.search(value)
+            if match == None:
+                break
+            cat, id = match.group(1, 2)
+            if cat != 'U' and cat != 'P':
+                break
+            start, end = match.start(0), match.end(0)
+            kpentry = self.keepass.find_entries(uuid=uuid.UUID(id))[0]
+            if kpentry == None:
+                value = value[:start] + value[end:]
+            else:
+                attr = 'password' if cat == 'P' else 'username'
+                if hasattr(kpentry, attr):
+                    attr = getattr(kpentry, attr)
+                    value = value[:start] + (attr if attr != None else '') + value[end:]
+                else:
+                    value = value[:start] + value[end:]
+        return value
 
     def parse(self):
         """Parse Keepass KDBX3 and KDBX4 files."""


### PR DESCRIPTION
Hello, I added support for automatic reference substitution when parsing `kdbx`-based keystores.

I haven't added any command-line parameter to enable or disable this behavior, because I cannot imagine a situation in which reference substitution would be undesirable/harmful, given that `pass` does not support references across password files and _KeePass(XC)_ references are useless in pass' usage context.

I read your contributing guidelines too and ran the tests with `make tests`.
Some tests failed, but I am positive it is not related to my changes; the downside is that I reduced your coverage score from **98%** (65, 109) down to **89%** (74-87, 94, 138) and I don't feel confident enough to write Python tests (I don't work with Python, just mess with it).