### PR TITLE
Handle entries with empty tags in passman manager

### DIFF
--- a/pass_import/managers/passman.py
+++ b/pass_import/managers/passman.py
@@ -72,8 +72,9 @@ class PassmanJSON(JSON):
         jsons = json.loads(self.file.read())
         for item in jsons:
             entry = dict()
-            group = item.get('tags', [])[0]['text']
-            entry['group'] = group.replace('\\', os.sep)
+            if item['tags']:
+                group = item['tags'][0]['text']
+                entry['group'] = group.replace('\\', os.sep)
             custom_fields = item.get('custom_fields', [])
             for field in custom_fields:
                 item.update({field['label']: field['value']})


### PR DESCRIPTION
Attempting to access the first element of an empty list will
`throw IndexError`. Tags are not a mandatory field for password entries
in PassMan and hence there can be entries without tags as well.

This situation would previously crash with
`IndexError: list index out of range`
obviously because of the attempt to access the zeroth element of an
empty list. This change fixes that situation.
