### PR TITLE
Fixes for `pass_import.clean.duplicate()`

### DIFF
--- a/pass_import/clean.py
+++ b/pass_import/clean.py
@@ -124,12 +124,14 @@ def duplicate(data):
     """Add number to the remaining duplicated path."""
     seen = set()
     for entry in data:
+        idx_added = False
         path = entry.get('path', '')
         if path in seen:
             idx = 1
             while path in seen:
-                if re.search(r'%s(\d+)$' % SEPARATOR, path) is None:
+                if not idx_added:
                     path += SEPARATOR + str(idx)
+                    idx_added = True
                 else:
                     path = re.sub(r'^(.*)%s%s$' % (SEPARATOR, str(idx)),
                                   r'\1%s%s' % (SEPARATOR, str(idx + 1)),

--- a/pass_import/clean.py
+++ b/pass_import/clean.py
@@ -131,8 +131,9 @@ def duplicate(data):
                 if re.search(r'%s(\d+)$' % SEPARATOR, path) is None:
                     path += SEPARATOR + str(idx)
                 else:
-                    path = path.replace(SEPARATOR + str(idx),
-                                        SEPARATOR + str(idx + 1))
+                    path = re.sub(r'^(.*)%s%s$' % (SEPARATOR, str(idx)),
+                                  r'\1%s%s' % (SEPARATOR, str(idx + 1)),
+                                  path)
                     idx += 1
             seen.add(path)
             entry['path'] = path

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -368,22 +368,22 @@ class TestCleanDuplicate(TestClean):
     def test_numbers(self):
         """Testing: duplicate with numbers."""
         self.store.data = [{
-            'title': 'ovh.com'
+            'title': 'ovh-2.com'
         }, {
-            'title': 'ovh.com'
+            'title': 'ovh-2.com'
         }, {
-            'title': 'ovh.com'
+            'title': 'ovh-2.com'
         }, {
-            'title': 'ovh.com'
+            'title': 'ovh-2.com'
         }]
         data_expected = [{
-            'path': 'ovh.com/notitle'
+            'path': 'ovh-2.com/notitle'
         }, {
-            'path': 'ovh.com/notitle-1'
+            'path': 'ovh-2.com/notitle-1'
         }, {
-            'path': 'ovh.com/notitle-2'
+            'path': 'ovh-2.com/notitle-2'
         }, {
-            'path': 'ovh.com/notitle-3'
+            'path': 'ovh-2.com/notitle-3'
         }]
         self.store.clean(False, False)
         self.assertEqual(self.store.data, data_expected)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -66,6 +66,64 @@ class TestStatic(tests.Test):
         string = pass_import.clean.replaces(characters, string)
         self.assertEqual(string, string_expected)
 
+    def test_duplicate(self):
+        """Testing: clean.replaces."""
+        data = [
+            {
+                'url': 'http://',
+                'login': 'tv-l2-0',
+                'password': 'pass1',
+                'path': '0/some-path/tv-l2-0'
+            },
+            {
+                'url': 'http://',
+                'login': 'tv-l2-1',
+                'password': 'pass2',
+                'path': '0/some-path/tv-l2-1'
+            },
+            {
+                'url': 'http://',
+                'login': 'tv-l2-0',
+                'password': 'pass3',
+                'path': '0/some-path/tv-l2-0'
+            },
+            {
+                'url': 'http://',
+                'login': 'tv-l2-0',
+                'password': 'pass4',
+                'path': '0/some-path/tv-l2-0'
+            },
+        ]
+        data_expected = [
+            {
+                'url': 'http://',
+                'login': 'tv-l2-0',
+                'password': 'pass1',
+                'path': '0/some-path/tv-l2-0'
+            },
+            {
+                'url': 'http://',
+                'login': 'tv-l2-1',
+                'password': 'pass2',
+                'path': '0/some-path/tv-l2-1'
+            },
+            {
+                'url': 'http://',
+                'login': 'tv-l2-0',
+                'password': 'pass3',
+                'path': '0/some-path/tv-l2-0-1'
+            },
+            {
+                'url': 'http://',
+                'login': 'tv-l2-0',
+                'password': 'pass4',
+                'path': '0/some-path/tv-l2-0-2'
+            },
+        ]
+        characters = {}
+        pass_import.clean.duplicate(data)
+        self.assertEqual(data, data_expected)
+
 
 class TestClean(tests.Test):
     """Base class for entry cleaning tests."""


### PR DESCRIPTION
This addresses problems documented in https://github.com/roddhjav/pass-import/issues/154. Tests are included.

```
$ python -m green -vvv tests/test_clean.py
Green 3.3.0, Coverage 5.5, Python 3.9.5

tests.test_clean
  TestCleanClean
.   Testing: convert password path.
.   Testing: clean data.
.   Testing: clean data - empty title and clean enabled.
.   Testing: clean data - login as path name.
.   Testing: clean data - notitle as path name.
.   Testing: clean data - remove separator from title.
.   Testing: clean data - url as path name.
  TestCleanDuplicate
.   Testing: duplicate with numbers.
.   Testing: duplicate paths.
.   Testing: duplicate to subfolder.
.   Testing: duplicate to two levels of subfolders.
  TestStatic
.   Testing: clean.cmdline.
.   Testing: clean.convert.
.   Testing: clean.convert with ~ as separator.
.   Testing: clean.replaces.
.   Testing: clean.group.
.   Testing: clean.protocol.
.   Testing: clean.replaces.
.   Testing: clean.title.

Ran 19 tests in 0.027s using 8 processes

OK (passes=19)
$