### PR TITLE
Read OTP from 1Password's 1pif format

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -175,8 +175,8 @@ Data are imported in PasswordManager.data, this is a list of ordered dict. Each
 entry is a dictionary that contains the data for a password store entry. The
 dictionary's keys are divided into two sets:
 
-1) The *standard keys*: `title`, `password`, `login`, `url`, `comments` and
-`group`.
+1) The *standard keys*: `title`, `password`, `login`, `email`, `url`, `comments`,
+`otpauth` and `group`.
 2) The *extra* keys that differ from password managers and contain the
 description of any extra data we can find in the exported file.
 

--- a/pass_import/formats/json.py
+++ b/pass_import/formats/json.py
@@ -121,6 +121,14 @@ class PIF(JSON):
                     key = keys.get(jsonkey, jsonkey)
                     entry[key] = field.get('value', '')
 
+                sections = scontent.get('sections', [])
+                for section in sections:
+                    sectionFields = section.get('fields', [])
+                    for sectionField in sectionFields:
+                        value = sectionField.get('v', '')
+                        if value.startswith('otpauth://'):
+                            entry['otpauth'] = value
+
                 item.update(scontent)
                 for key, value in item.items():
                     if key not in self.ignore:


### PR DESCRIPTION
This PR adds OTP support for 1Password's 1pif format.
I ran it locally and it worked for me.
ref #116 