### PR TITLE
Skip 1password item if it's trashed

### DIFF
--- a/pass_import/formats/json.py
+++ b/pass_import/formats/json.py
@@ -111,6 +111,8 @@ class PIF(JSON):
                 }
 
             elif item.get('typeName', '') == 'webforms.WebForm':
+                if item.get('trashed', False):
+                    continue
                 entry = dict()
                 scontent = item.pop('secureContents', {})
                 fields = scontent.pop('fields', [])


### PR DESCRIPTION
I tried to migrate from 1Password to pass, and `pass-import` also imported all the trashed items.
Sometimes the items are considered duplicated and the trashed ones are chosen.
It helps if the trashed items are ignored.