### PR TITLE
terminate the GnuPG commandline

### DIFF
--- a/pass_import/managers/passwordstore.py
+++ b/pass_import/managers/passwordstore.py
@@ -224,7 +224,13 @@ class PasswordStore(CLI, Formatter):
             if gpgids[len(gpgids)-1] == '':
                 gpgids.pop()
 
-        cmd = [self._gpgbinary, '--with-colons', '--batch', '--list-keys']
+        cmd = [
+            self._gpgbinary,
+            '--with-colons',
+            '--batch',
+            '--list-keys',
+            '--',
+        ]
         for gpgid in gpgids:
             res, out, _ = self._call(cmd + [gpgid])
             if res:
@@ -237,7 +243,11 @@ class PasswordStore(CLI, Formatter):
                 return False
 
         cmd = [
-            self._gpgbinary, '--with-colons', '--batch', '--list-secret-keys'
+            self._gpgbinary,
+            '--with-colons',
+            '--batch',
+            '--list-secret-keys',
+            '--',
         ]
         for gpgid in gpgids:
             res, _, _ = self._call(cmd + [gpgid])


### PR DESCRIPTION
This is a safety measure to ensure that GnuPG may not be fed arbitrary
commandline arguments from the .gpg-id file. Normally, that file is
considered trusted, but it might be possible, in a multi-user
password-store, that it contains untrusted input from other users,
even if signed.

In that sense, it's technically possible for other users to add
arbitrary content in there, and therefore arbitrary commandline
arguments to GnuPG. There are two things that mitigate that possible
security issue already:

 1. each .gpg-id line is passed individually, in a list, so it will
    not get expanded by a shell, which also means only a single
    argument can be passed

 2. the --list-keys argument is already passed, so it is probably
    not possible to change the "mode" of GnuPG (say make it encrypt or
    sign content)

However, the GnuPG commandline interface being particularly
unscrutable, it seems safer to terminate the commandline using the
colloquial --.

This is copied from pass-audit, in:

https://github.com/roddhjav/pass-audit/pull/28

... but the same audit was not performend on pass-import.