### PR TITLE
fix pykeepass find_groups usage

### DIFF
--- a/pass_import/formats/kdbx.py
+++ b/pass_import/formats/kdbx.py
@@ -161,7 +161,7 @@ class KDBX(Formatter, PasswordImporter, PasswordExporter):
         group = os.path.dirname(path)
 
         root_group = self.keepass.root_group
-        kpgroup = self.keepass.find_groups(path=group)
+        kpgroup = self.keepass.find_groups(name=group, first=True)
         if not kpgroup:
             for grp in group.split('/'):
                 kpgroup = self.keepass.find_groups(path=grp)


### PR DESCRIPTION
The pykeepass README shows the proper usage; the way it's being used right now leads to "group" being None and "path" getting stripped of it's rightmost character, e.g. "Notes" -> "Note" in the internal `_find()` method in pykeepass.py: `group_path = path[:-1]`; causing no groups to actually get found so a new one is added for every loop. Your KDBX file ends up with a new group for every item that's supposed to be in the same single group with the passed in item - using the documented method, groups are properly found if they exist.