### PR TITLE
Fix pykeepass use of find_groups path parameter

### DIFF
--- a/pass_import/formats/kdbx.py
+++ b/pass_import/formats/kdbx.py
@@ -164,9 +164,9 @@ class KDBX(Formatter, PasswordImporter, PasswordExporter):
         group = os.path.dirname(path)
 
         root_group = self.keepass.root_group
-        kpgroup = self.keepass.find_groups(path=group)
+        kpgroup = self.keepass.find_groups(path=os.path.split(path))
         if not kpgroup:
-            for grp in group.split('/'):
+            for grp in os.path.split(group):
                 kpgroup = self.keepass.find_groups(path=grp)
                 if not kpgroup:
                     kpgroup = self.keepass.add_group(root_group, grp)


### PR DESCRIPTION
Better fix to use instead of PR #171 given that the pykeepass reference doc is its [README](https://github.com/libkeepass/pykeepass/blob/master/README.rst) as stated in https://github.com/libkeepass/pykeepass/issues/313