### PR TITLE
removing duplicate line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,7 @@ database to a generic CSV file...
       <td align="center"><code>pass import buttercup file.csv</code></td>
     </tr>
     <tr>
-      <td align="center" rowspan="2"><a href="https://support.google.com/chrome">chrome</a></td>
-      <td align="center"><code>csv</code></td>
-      <td align="center"><i>See <a href="https://support.google.com/chrome/answer/95606#see">this guide</a></i></td>
-      <td align="center"><code>pass import chrome file.csv</code></td>
-    </tr>
-    <tr>
+      <td align="center" rowspan="1"><a href="https://support.google.com/chrome">chrome</a></td>
       <td align="center"><code>csv</code></td>
       <td align="center"><i>See <a href="https://support.google.com/chrome/answer/95606#see">this guide</a></i></td>
       <td align="center"><code>pass import chrome file.csv</code></td>
@@ -570,7 +565,7 @@ pass import lastpass lastpass.csv.gpg
 
 **Mandatory Access Control (MAC)**
 
-AppArmor profiles for `pass` and `pass-import` are available in 
+AppArmor profiles for `pass` and `pass-import` are available in
 [`apparmor.d`][apparmor.d]. If your distribution support AppArmor, you can
 clone the [apparmor.d] and run: `sudo ./pick pass pass-import` to only install
 these apparmor security profiles.


### PR DESCRIPTION
I noticed a duplicate line in the README for the chrome instructions (and my linter noticed a dangling space), which this super useful commit should fix. Thanks for the software! I just used it to migrate.