### PR TITLE
Fix kdbx import bug (None in kpentry.path)

### DIFF
--- a/pass_import/formats/kdbx.py
+++ b/pass_import/formats/kdbx.py
@@ -135,7 +135,7 @@ class KDBX(Formatter, PasswordImporter, PasswordExporter):
     def parse(self):
         """Parse Keepass KDBX3 and KDBX4 files."""
         for kpentry in self.keepass.entries:
-            if self.root not in os.sep.join(kpentry.path):
+            if self.root not in os.sep.join(filter(None, kpentry.path)):
                 continue
             entry = self._getentry(kpentry)
             entry['group'] = os.path.dirname(entry.get('group', ''))


### PR DESCRIPTION
Found yet another bug with `None` values appearing in `kpentry.path`, the fix is to filter all `None` values before doing `str.join`.

Before this fix, I was getting:

```python
Traceback (most recent call last):
  File "pass_import/__main__.py", line 354, in pass_import
    importer.parse()
  File "pass_import/formats/kdbx.py", line 140, in parse
    if self.root not in os.sep.join(kpentry.path):
TypeError: sequence item 1: expected str instance, NoneType found
```

After some debuggin, found, that `kpentry.path` contains `None` values.

Related issue: https://github.com/roddhjav/pass-import/issues/161.