### PR TITLE
Don't bail on passwords longer than 72 chars

### DIFF
--- a/pass_import/audit.py
+++ b/pass_import/audit.py
@@ -92,9 +92,14 @@ class Audit():
             user_input = list(entry.values())
             if password in user_input:
                 user_input.remove(password)
-            results = zxcvbn(password, user_inputs=user_input)
-            if results['score'] <= 2:
-                self.weak.append((password, results))
+            try:
+                results = zxcvbn(password, user_inputs=user_input)
+                if results['score'] <= 2:
+                    self.weak.append((password, results))
+            except ValueError:
+                # zxcvbn raises ValueError on passwords greater than 72 chars.
+                # Anything that long needn't be appended to `self.weak`.
+                pass
 
     def duplicates(self):
         """Check for duplicated passwords."""


### PR DESCRIPTION
For reference, [`zxcvbn`'s signature](https://github.com/dwolfhub/zxcvbn-python/blob/d32d30bed67352c9c28c9ae3be4fc889bee13cab/zxcvbn/__init__.py#L7).

<details><summary>Why not zxcvbn(max_length=ARBITRARILY_HIGH_NUMBER)?</summary>

I reasoned that `max_length` exists to prevent arbitrarily-long strings from sucking up too much CPU time.

```python
>>> from zxcvbn import zxcvbn
>>> from timeit import timeit
>>> test = lambda i: zxcvbn(password="a"*i, max_length=i)
>>> timeit(lambda: test(100), number=1)
0.02540450499873259
>>> timeit(lambda: test(500), number=1)
2.764077340001677
```
(Of course, a string like `"a"*500` will still score 1, but that's an edge case this PR shan't deal with.)
</details>