### PR TITLE
feat: add importer for Synology C2 Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-`pass import` is a password store extension allowing you to import your password database to a password store repository conveniently. It natively supports import from <!-- NB BEGIN -->62<!-- NB END --> different password managers. More manager support can easily be added.
+`pass import` is a password store extension allowing you to import your password database to a password store repository conveniently. It natively supports import from <!-- NB BEGIN -->63<!-- NB END --> different password managers. More manager support can easily be added.
 
 Passwords are imported into the existing default password store, therefore the password store must have been initialized before with `pass init`.
 
@@ -363,6 +363,12 @@ pass-import also provides a `pimport` script that allows importing passwords to 
       <td align="center"><code>pass import saferpass file.csv</code></td>
     </tr>
     <tr>
+      <td align="center" rowspan="1"><a href="https://c2.synology.com/en-global/password/overview">synology</a></td>
+      <td align="center"><code>csv</code></td>
+      <td align="center"><i>Profile > Export > Download</i></td>
+      <td align="center"><code>pass import synology file.csv</code></td>
+    </tr>
+    <tr>
       <td align="center" rowspan="1"><a href="http://upm.sourceforge.net">upm</a></td>
       <td align="center"><code>csv</code></td>
       <td align="center"><i>Database > Export</i></td>
@@ -421,8 +427,9 @@ pimport <new_pm> <former_pm> path/to/passwords --out path/to/destination/pm
 ### Help
 <!-- USAGE BEGIN -->
 ```
-usage: pass import [-r path] [-p path] [-k KEY] [-a] [-f] [-c] [-C] [-P] [-d] [--sep CHAR] [--del CHAR] [--cols COLS] [--filter FILTER] [--config CONFIG]
-                   [-l] [-h] [-V] [-v | -q]
+usage: pass import [-r path] [-p path] [-k KEY] [-a] [-f] [-c] [-C] [-P] [-d]
+                   [--sep CHAR] [--del CHAR] [--cols COLS] [--filter FILTER]
+                   [--config CONFIG] [-l] [-h] [-V] [-v | -q]
                    [src ...]
 
   Import data from most of the password manager. Passwords are imported into
@@ -430,11 +437,17 @@ usage: pass import [-r path] [-p path] [-k KEY] [-a] [-f] [-c] [-C] [-P] [-d] [-
   been initialised before with 'pass init'.
 
 Password managers:
-  src                   Path to the data to import. Can also be the password manager name followed by the path to the data to import. The password manager
-                        name can be: 1password, aegis, andotp, apple-keychain, bitwarden, blur, buttercup, chrome, clipperz, csv, dashlane, encryptr,
-                        enpass, firefox, fpm, freeotp+, gnome, gnome-auth, gopass, gorilla, kedpm, keepass, keepassx, keepassx2, keepassxc, keeper,
-                        lastpass, myki, network-manager, nordpass, padlock, pass, passman, passpack, passpie, pwsafe, revelation, roboform, safeincloud,
-                        saferpass, upm, zoho.
+  src                   Path to the data to import. Can also be the password
+                        manager name followed by the path to the data to
+                        import. The password manager name can be: 1password,
+                        aegis, andotp, apple-keychain, bitwarden, blur,
+                        buttercup, chrome, clipperz, csv, dashlane, encryptr,
+                        enpass, firefox, fpm, freeotp+, gnome, gnome-auth,
+                        gopass, gorilla, kedpm, keepass, keepassx, keepassx2,
+                        keepassxc, keeper, lastpass, myki, network-manager,
+                        nordpass, padlock, pass, passman, passpack, passpie,
+                        pwsafe, revelation, roboform, safeincloud, saferpass,
+                        synology, upm, zoho.
 
 Common optional arguments:
   -r path, --root path  Only import the password from a specific subfolder.
@@ -445,15 +458,23 @@ Common optional arguments:
   -c, --clean           Make the paths more command line friendly.
   -C, --convert         Convert invalid characters present in the paths.
   -P, --pwned           Check imported passwords against haveibeenpwned.com.
-  -d, --dry-run         Do not import passwords, only show what would be imported.
+  -d, --dry-run         Do not import passwords, only show what would be
+                        imported.
 
 Extra optional arguments:
-  --sep CHAR            Provide a characters of replacement for the path separator. Default: '-'
-  --del CHAR            Provide an alternative CSV delimiter character. Default: ','
-  --cols COLS           CSV expected columns to map columns to credential attributes. Only used by the csv importer.
-  --filter FILTER       Export whole entries matching a JSONPath filter expression. Default: (none) This field can be: - a string JSONPath expression - an
-                        absolute path to a file containing a JSONPath filter expression. List of supported filter: https://github.com/h2non/jsonpath-ng
-                        Example: - '$.entries[*].tags[?@="Defaults"]' : Export only entries with a tag matching 'Defaults'
+  --sep CHAR            Provide a characters of replacement for the path
+                        separator. Default: '-'
+  --del CHAR            Provide an alternative CSV delimiter character.
+                        Default: ','
+  --cols COLS           CSV expected columns to map columns to credential
+                        attributes. Only used by the csv importer.
+  --filter FILTER       Export whole entries matching a JSONPath filter
+                        expression. Default: (none) This field can be: - a
+                        string JSONPath expression - an absolute path to a
+                        file containing a JSONPath filter expression. List of
+                        supported filter: https://github.com/h2non/jsonpath-ng
+                        Example: - '$.entries[*].tags[?@="Defaults"]' : Export
+                        only entries with a tag matching 'Defaults'
   --config CONFIG       Set a config file. Default: '.import'
 
 Help related optional arguments:

--- a/pass_import/managers/__init__.py
+++ b/pass_import/managers/__init__.py
@@ -40,5 +40,6 @@ from pass_import.managers.roboform import Roboform
 from pass_import.managers.safeincloud import SafeInCloudCSV
 from pass_import.managers.saferpass import SaferPass
 from pass_import.managers.sphinx import Sphinx
+from pass_import.managers.synology import SynologyC2CSV
 from pass_import.managers.upm import UPM
 from pass_import.managers.zoho import ZohoCSV, ZohoCSVVault

--- a/pass_import/managers/synology.py
+++ b/pass_import/managers/synology.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+# pass import - Passwords importer swiss army knife
+# Copyright (C) 2024 SAY-5 <say.apm35@gmail.com>.
+#
+
+from pass_import.core import register_managers
+from pass_import.formats.csv import CSV
+
+
+class SynologyC2CSV(CSV):
+    """Importer for Synology C2 Password in CSV format."""
+    name = 'synology'
+    url = 'https://c2.synology.com/en-global/password/overview'
+    hexport = 'Profile > Export > Download'
+    himport = 'pass import synology file.csv'
+    encoding = 'utf-8-sig'
+    keys = {
+        'title': 'Display_Name',
+        'login': 'Login_Username',
+        'password': 'Login_Password',
+        'url': 'Login_URLs',
+        'otpauth': 'Login_TOTP',
+        'comments': 'Notes'
+    }
+
+
+register_managers(SynologyC2CSV)

--- a/share/bash-completion/completions/pass-import
+++ b/share/bash-completion/completions/pass-import
@@ -9,7 +9,7 @@ __password_store_extension_complete_import() {
 		freeotp+ gnome gnome-auth gopass gorilla kedpm keepass keepassx 
 		keepassx2 keepassxc keeper lastpass myki network-manager nordpass 
 		padlock pass passman passpack passpie pwsafe revelation roboform 
-		safeincloud saferpass upm zoho)
+		safeincloud saferpass synology upm zoho)
 	# importers end
 	local args=(-r --root -p --path -k --key -a --all -f --force -c --clean
 		-C --convert --sep --del --cols --filter --config -l --list -h --help

--- a/share/bash-completion/completions/pimport
+++ b/share/bash-completion/completions/pimport
@@ -12,7 +12,7 @@ _pimport() {
 		freeotp+ gnome gnome-auth gopass gorilla kedpm keepass keepassx 
 		keepassx2 keepassxc keeper lastpass myki network-manager nordpass 
 		padlock pass passman passpack passpie pwsafe revelation roboform 
-		safeincloud saferpass upm zoho)
+		safeincloud saferpass synology upm zoho)
 	# importers end
 	local args=(-r --root -p --path -k --key -a --all -f --force -c --clean
 		-C --convert --sep --del --cols --config --filter -l --list -h --help

--- a/share/man/man1/pass-import.md
+++ b/share/man/man1/pass-import.md
@@ -13,7 +13,7 @@ the existing password manager.
 
 # DESCRIPTION
 
-**pass import** is a password store extension allowing you to import your password database to a password store repository conveniently. It natively supports import from <!-- NB BEGIN -->62<!-- NB END --> different password managers. More manager support can easily be added.
+**pass import** is a password store extension allowing you to import your password database to a password store repository conveniently. It natively supports import from <!-- NB BEGIN -->63<!-- NB END --> different password managers. More manager support can easily be added.
 
 Passwords are imported into the existing default password store, therefore the password store must have been initialized before with **pass init**.
 
@@ -711,6 +711,13 @@ invalids:
 **Export:** Settings > Export Data: Export data
 
 **Command:** pass import saferpass file.csv
+
+### synology (csv) 
+**Website:** *https://c2.synology.com/en-global/password/overview*
+
+**Export:** Profile > Export > Download
+
+**Command:** pass import synology file.csv
 
 ### upm (csv) 
 **Website:** *http://upm.sourceforge.net*

--- a/share/man/man1/pimport.md
+++ b/share/man/man1/pimport.md
@@ -12,7 +12,7 @@ pimport —  A passwords importer swiss army knife
 
 # DESCRIPTION
 
-**pimport** is a passwords importer swiss army knife allowing you to import your password database to a password store repository conveniently. It natively supports import from <!-- NB BEGIN -->62<!-- NB END --> password managers, and export to <!-- NB EXPORT BEGIN -->8<!-- NB EXPORT END --> destination password managers. More manager support can easily be added.
+**pimport** is a passwords importer swiss army knife allowing you to import your password database to a password store repository conveniently. It natively supports import from <!-- NB BEGIN -->63<!-- NB END --> password managers, and export to <!-- NB EXPORT BEGIN -->8<!-- NB EXPORT END --> destination password managers. More manager support can easily be added.
 
 Passwords are imported into the existing default password store, therefore the password store must have been initialized before.
 
@@ -754,6 +754,13 @@ invalids:
 **Export:** Settings > Export Data: Export data
 
 **Command:** pass import saferpass file.csv
+
+### synology (csv) 
+**Website:** *https://c2.synology.com/en-global/password/overview*
+
+**Export:** Profile > Export > Download
+
+**Command:** pass import synology file.csv
 
 ### upm (csv) 
 **Website:** *http://upm.sourceforge.net*

--- a/share/zsh/site-functions/_pass-import
+++ b/share/zsh/site-functions/_pass-import
@@ -51,6 +51,7 @@ _pass-import () {
 			'roboform:Importer for roboform in CSV'
 			'safeincloud:Importer for safeincloud in CSV'
 			'saferpass:Importer for saferpass in CSV'
+			'synology:Importer for synology in CSV'
 			'upm:Importer for upm in CSV'
 			'zoho:Importer for zoho in CSV, CSV'
 		)

--- a/share/zsh/site-functions/_pimport
+++ b/share/zsh/site-functions/_pimport
@@ -53,6 +53,7 @@ _pimport () {
 			'roboform:Importer for roboform in CSV'
 			'safeincloud:Importer for safeincloud in CSV'
 			'saferpass:Importer for saferpass in CSV'
+			'synology:Importer for synology in CSV'
 			'upm:Importer for upm in CSV'
 			'zoho:Importer for zoho in CSV, CSV'
 		)

--- a/tests/assets/db/synology.csv
+++ b/tests/assets/db/synology.csv
@@ -1,0 +1,16 @@
+﻿Display_Name,Login_Username,Login_Password,Login_URLs,Login_TOTP,Notes,Favorite
+mastodon.social,ostqxi,D<INNeT?#?Bf4%`zA/4i!/'$T,https://mastodon.social/,,,
+twitter.com,ostqxi,"SoNEwvU,kJ%-cIKJ9[c#S;]jB",https://twitter.com/,,,
+https://news.ycombinator.com,ostqxi,"1)Btf2EI~Tfb7g2A!Sy',*Sj#",https://news.ycombinator.com,,,
+ovh.com,jsdkyvbwjn,^Vr/|o>_H8X%T]7>f}7|:U!Zs,https://www.ovh.com/manager/web/,,,
+ovh.com,bynbyjhqjz,"3Z-VW!i,j(&!zRGPu(hFe]s'(",https://www.ovh.com/manager/web/,,,
+aib,dpbx@fner.ws,"ws5T@;_UB[Q|P!8'`~z%XC'JHFUbf#IX _E0}:HF,[{ei0hBg14",https://onlinebanking.aib.ie,,,
+dpbx@afoqwdr.tx,dpbx,9KVHnx:.S_S;cF`=CE@e\p{v6,https://afoqwdr.tx,,,
+dpbx@klivak.xb,dpbx,"2cUqe}e9}>IVZf)Ye>3C8ZN,r",,,This is a garbage address,
+dpbx@mnyfymt.ws,dpbx,rPCkmNkhIa>{izt3C3F823!Go,https://mail.mnyfymt.ws,,,
+dpbx@fner.ws,dpbx,"mt}h'hSUCY;SU;;A!l[8y3O:8",,,For financial purpose only!,
+space title,vkeelpbu,]stDKo{%pk,https://nhysdo.wg,,,
+empty entry,,,,,,
+empty password,vkeelpbu,,https://nhysdo.wg,,,
+note,,,,,"This is a multiline note entry. Cube shank petroleum guacamole dart mower
+acutely slashing upper cringing lunchbox tapioca wrongful unbeaten sift.",

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -71,7 +71,7 @@ class TestDetect(tests.Test):
 
     def test_manager(self):
         """Testing: manager for all managers."""
-        wrong_file_mode = {'SaferPass', 'ZohoCSV', 'ZohoCSVVault'}
+        wrong_file_mode = {'SaferPass', 'SynologyC2CSV', 'ZohoCSV', 'ZohoCSVVault'}
         prefix_is_a_login = {'GnomeKeyring', 'BitwardenCLI', 'OnePasswordCLI',
                              'LastpassCLI'}
         csv_without_header = {'DashlaneCSV', 'KeeperCSV', 'UPM'}

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -228,6 +228,11 @@ SaferPass:
   without:
     - group
 
+SynologyC2CSV:
+  path: synology.csv
+  without:
+    - group
+
 UPM:
   path: upm.csv
   without:


### PR DESCRIPTION
Adds a CSV importer for Synology C2 Password, requested in #240.

The owner endorsed a PR in the issue:
> Without access to such a password manager, I won't be able to generate an exported CSV with the expected data, so no. However, PR are welcome.

Implementation follows the field mapping documented in the issue:

| C2 Password column | pass-import field |
|--------------------|-------------------|
| Display_Name       | title             |
| Login_Username     | login             |
| Login_Password     | password          |
| Login_URLs         | url               |
| Login_TOTP         | otpauth           |
| Notes              | comments          |

Changes:
- pass_import/managers/synology.py: new SynologyC2CSV importer (utf-8-sig, no extra parse logic needed)
- registered in pass_import/managers/__init__.py
- tests/assets/db/synology.csv: reference export per tests/assets/references/main.yml
- tests.yml entry SynologyC2CSV
- regenerated README table and man/completion files via make docs

Closes #240