### PR TITLE
fix: handle zxcvbn 72-char limit for long passwords during audit

### DIFF
--- a/pass_import/__main__.py
+++ b/pass_import/__main__.py
@@ -482,6 +482,9 @@ def report(conf, paths_imported, paths_exported, audit):
     for entry in audit['duplicated']:
         conf.warning(f"Duplicated passwords detected: "
                      f"{', '.join([item['path'] for item in entry])}")
+    for entry in audit.get('skipped', []):
+        conf.warning(f"Password too long for strength estimation (>72 chars),"
+                     f" skipped: {entry.get('path', entry.get('title', ''))}")
 
     for paths, header in [
         (paths_imported, "Passwords imported"),

--- a/pass_import/audit.py
+++ b/pass_import/audit.py
@@ -50,6 +50,7 @@ class Audit():
         self.breached = []
         self.weak = []
         self.duplicated = []
+        self.skipped = []
 
     @property
     def report(self):
@@ -57,7 +58,8 @@ class Audit():
         return {
             'breached': self.breached,
             'weak': self.weak,
-            'duplicated': self.duplicated
+            'duplicated': self.duplicated,
+            'skipped': self.skipped,
         }
 
     def password(self):
@@ -89,6 +91,9 @@ class Audit():
             if entry.get('password', '') == '':
                 continue
             password = entry['password']
+            if len(password) > 72:
+                self.skipped.append(entry)
+                continue
             user_input = list(entry.values())
             if password in user_input:
                 user_input.remove(password)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -84,6 +84,18 @@ class TestAudit(tests.Test):
         audit.zxcvbn()
         self.assertTrue(len(audit.weak) == 0)
 
+    def test_zxcvbn_long(self):
+        """Testing: audit skips passwords exceeding zxcvbn's 72-char limit."""
+        data = [{
+            'path': 'Password/long/1',
+            'password': 'x' * 73,
+            'group': 'Password/long'
+        }]
+        audit = pass_import.audit.Audit(data)
+        audit.zxcvbn()
+        self.assertTrue(len(audit.weak) == 0)
+        self.assertTrue(len(audit.skipped) == 1)
+
     def test_duplicates_yes(self):
         """Testing: audit for duplicates password."""
         data = getpath('Password/notpwned/1')


### PR DESCRIPTION
Passwords exceeding zxcvbn's 72-character maximum are skipped instead of crashing with an unhandled ValueError. A warning is emitted for each skipped entry so the user is informed.

```
$ pass import keepassx.kdbx
Password for keepassx.kdbx: 
Traceback (most recent call last):
  File "<frozen runpy>", line 203, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3.14/site-packages/pass_import/__main__.py", line 519, in <module>
    main()
    ~~~~^^
  File "/usr/lib/python3.14/site-packages/pass_import/__main__.py", line 512, in main
    paths_imported, paths_exported, audit = pass_export(conf, cls_export, data)
                                            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/pass_import/__main__.py", line 400, in pass_export
    report = exporter.audit(conf['pwned'])
  File "/usr/lib/python3.14/site-packages/pass_import/manager.py", line 186, in audit
    audit.zxcvbn()
    ~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/pass_import/audit.py", line 98, in zxcvbn
    results = zxcvbn(password, user_inputs=user_input)
  File "/usr/lib/python3.14/site-packages/zxcvbn/__init__.py", line 10, in zxcvbn
    raise ValueError(f"Password exceeds max length of {max_length} characters.")
ValueError: Password exceeds max length of 72 characters.
```