### PR TITLE
feat(synology): add support for custom fields in C2 Password CSV

### DIFF
--- a/pass_import/manager.py
+++ b/pass_import/manager.py
@@ -4,7 +4,7 @@
 #
 
 import os
-from typing import Dict
+from typing import Dict, List
 from abc import abstractmethod
 
 from pass_import import clean
@@ -46,7 +46,7 @@ class PasswordManager(Asset):
     def __init__(self, prefix=None, settings=None):
         settings = {} if settings is None else settings
 
-        self.data: Dict[str, str] = []
+        self.data: List[Dict[str, str]] = []
         self.root = settings.get('root', '')
         self.cols = settings.get('cols', '')
         self.action = settings.get('action', Cap.IMPORT)

--- a/pass_import/managers/synology.py
+++ b/pass_import/managers/synology.py
@@ -1,10 +1,28 @@
 # -*- encoding: utf-8 -*-
 # pass import - Passwords importer swiss army knife
 # Copyright (C) 2024 SAY-5 <say.apm35@gmail.com>.
+# Copyright (C) 2026 Ahmad Othman <ahmad.ali.othman@outlook.com>.
 #
 
+from pass_import.errors import FormatError
+import json
+from typing import TypedDict
 from pass_import.core import register_managers
 from pass_import.formats.csv import CSV
+
+
+class CustomAutofillField(TypedDict):
+    Type: str
+    AutofillWeb_Title: str
+    AutofillWeb_Type: str
+    AutofillWeb: str
+    AutofillWeb_Selector: str
+
+
+class CustomTextField(TypedDict):
+    Type: str
+    Text_Title: str
+    Text: str
 
 
 class SynologyC2CSV(CSV):
@@ -22,6 +40,33 @@ class SynologyC2CSV(CSV):
         'otpauth': 'Login_TOTP',
         'comments': 'Notes'
     }
+
+    def parse(self):
+        """Parse C2 Password CSV file, handling custom fields in Others column."""
+        super().parse()
+        for entry in self.data:
+            entry.pop("Login_URL_Match_Rules", None)
+            entry.pop("Tag", None)
+            entry.pop("Tag_Color", None)
+            entry.pop("Favorite", None)
+
+            raw = entry.pop("Others", "")
+            if raw and raw.strip():
+                try:
+                    others = json.loads(raw)
+                    if "Custom" in others:
+                        custom = others.get("Custom")
+                        if isinstance(custom, list):
+                            for item in custom:
+                                if item["Type"] == "Text":
+                                    field: CustomTextField = item
+                                    entry[field["Text_Title"].title()] = field["Text"]
+                                elif item["Type"] == "AutofillWeb":
+                                    field: CustomAutofillField = item
+                                    entry[field["AutofillWeb_Title"].title()] = field["AutofillWeb"]
+
+                except json.JSONDecodeError as e:
+                    raise FormatError(f"Invalid JSON in 'Others' column: {e}")
 
 
 register_managers(SynologyC2CSV)

--- a/tests/assets/db/c2password-malformed.csv
+++ b/tests/assets/db/c2password-malformed.csv
@@ -1,0 +1,2 @@
+Display_Name,Login_Username,Login_Password,Login_URLs,Login_TOTP,Login_URL_Match_Rules,Notes,Tag,Tag_Color,Favorite,Others
+broken,user,pass,https://x.com,,tld-plus-one,,,,,"not valid json at all"

--- a/tests/assets/db/c2password.csv
+++ b/tests/assets/db/c2password.csv
@@ -1,0 +1,234 @@
+﻿Login_URLs,Login_URL_Match_Rules,Login_Username,Login_Password,Login_TOTP,Display_Name,Tag,Tag_Color,Favorite,Notes,Others
+https://obsidian.md/account/,tld-plus-one,claudia22@example.com,zVhw534B6HQy,,obsidian.md,,,,,
+https://client.googiehost.com/cart.php?a=checkout&e=false,tld-plus-one,vsmith@example.com,Mci^A7*gUw6qMp,,client.googiehost.com,,,,,
+https://github.com,tld-plus-one,MichaelWhite,9rXQ4Xyl^7,otpauth://totp/GitHub:MichaelWhite?secret=9CZBZAOFRM&issuer=GitHub,github.com,,,,,
+https://en.wikipedia.org/w/index.php,tld-plus-one,HollyHowell,#x5JMrV^7+,,wikipedia.org,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Confirm password"",
+      ""AutofillWeb_Type"": ""password"",
+      ""AutofillWeb"": ""#x5JMrV^7+"",
+      ""AutofillWeb_Selector"": ""#wpRetype""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Email address (recommended)"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""vsmith@example.com"",
+      ""AutofillWeb_Selector"": ""#wpEmail""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""CAPTCHA Security check"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""deathdonna"",
+      ""AutofillWeb_Selector"": ""#mw-input-captchaWord""
+    }
+  ]
+}"
+https://my.anydesk.com/auth/realms/myanydesk/protocol/openid-connect/auth?client_id=myanydesk-frontend&code_challenge=G380ldjh0ubWB6JBYdgyw8uoLyzcIiVrP8ROOBdyin0ZT&code_challenge_method=S256&kc_idp_hint=custom-idp&redirect_uri=https%3A%2F%2Fmy.anydesk.com%2Fv2%2F&response_mode=fragment&response_type=code&scope=openid&state=c27cd912-3334-465e-91be-71ba776eea64&ui_locales=en,tld-plus-one,vsmith@example.com,RAYb0h4idYOCLpL2,,my.anydesk.com,,,,,
+android://iQcLnIDl0CGP7IFOyNzMVJOH-vdIhdpXQeivuFwnPTwzZxhGNycafCfQkV8AqCwwNnMKdE3Yb9upiC2MlkcDfA==@com.facebook.katana/,tld-plus-one,01234567890,$ri3sPuLw4,,android://iQcLnIDl0CGP7IFOyNzMVJOH-vdIhdpXQeivuFwnPTwzZxhGNycafCfQkV8AqCwwNnMKdE3Yb9upiC2MlkcDfA==@com.facebook.katana/,,,,,
+https://codeforces.com/register,tld-plus-one,claudia22@example.com,&x35h@Fz6I,,codeforces.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Text"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""JohnLucero"",
+      ""AutofillWeb_Selector"": ""[name=\""handle\""]""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Password"",
+      ""AutofillWeb_Type"": ""password"",
+      ""AutofillWeb"": ""&x35h@Fz6I"",
+      ""AutofillWeb_Selector"": ""[name=\""passwordConfirmation\""]""
+    }
+  ]
+}"
+https://account.proton.me/pass/signup,tld-plus-one,claudia22@example.com,)5R+Tw)Nx8,,proton.me,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Password"",
+      ""AutofillWeb_Type"": ""password"",
+      ""AutofillWeb"": "")5R+Tw)Nx8"",
+      ""AutofillWeb_Selector"": ""#password""
+    }
+  ]
+}"
+https://phpmyadmin.freedb.tech,tld-plus-one,freedb_John,M!JPQbyJ@4,,https://phpmyadmin.freedb.tech,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Server:"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""sql.freedb.tech"",
+      ""AutofillWeb_Selector"": ""#serverNameInput""
+    }
+  ]
+}"
+https://scribehow.com/signup,tld-plus-one,vsmith@example.com,2_2I8EnO67,,scribehow.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Full name"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""Heather Costa"",
+      ""AutofillWeb_Selector"": ""#name""
+    }
+  ]
+}"
+https://www.tybaa.com,tld-plus-one,محمد_عبد_الشكور,$)_nAMxh!9,,tybaa.com,,,,,
+archlinux.org,tld-plus-one,SusanGillespie,*G3#HVArU!,,archlinux.org,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""Text"",
+      ""Text_Title"": ""Email"",
+      ""Text"": ""claudia22@example.com""
+    }
+  ]
+}"
+https://x.com/i/flow/password_reset,tld-plus-one,,g^k_9J7oKT,,x.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Enter a new password"",
+      ""AutofillWeb_Type"": ""password"",
+      ""AutofillWeb"": ""g^k_9J7oKT"",
+      ""AutofillWeb_Selector"": "".css-175oi2r:nth-child(1) > .css-175oi2r > .css-146c3p1 > [name=\""password\""]""
+    }
+  ]
+}"
+http://127.0.0.1:65000/web/register,tld-plus-one,claudia22@example.com,"Qae.=`0z''hG*FK{4W!8:s,G""",,127.0.0.1:65000,,,,,
+https://account.postmarkapp.com/sign_up,tld-plus-one,vsmith@example.com,^lBb)!&dA9,,account.postmarkapp.com,,,,,
+https://app.clickup.com/,tld-plus-one,claudia22@example.com,da2eTfLqB%,,clickup.com,,,,,"{
+  ""Login_Autosave_Web_Anti_Selectors"": [
+    ""#password-input""
+  ]
+}"
+"https://auth0.openai.com
+https://chatgpt.com","tld-plus-one
+tld-plus-one",claudia22@example.com,=#FhcshvymJ6Dc5,otpauth://totp/OpenAI%3Aqmorrison%40example.org?secret=Z7oWE5HLuWARlRQ4p5ABkN8M86iNcwIC&issuer=OpenAI,auth0.openai.com,,,,,
+https://windscribe.com/signup,tld-plus-one,Cindy_Johnson,T!JUAWjg(7,,windscribe.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Email (Optional)"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""iramirez@example.com"",
+      ""AutofillWeb_Selector"": ""#signup_email""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Enter Captcha"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""X6cmY"",
+      ""AutofillWeb_Selector"": ""#captcha1""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Choose Password"",
+      ""AutofillWeb_Type"": ""password"",
+      ""AutofillWeb"": ""pUZ(4Xhzl9"",
+      ""AutofillWeb_Selector"": ""#pass1""
+    }
+  ]
+}"
+https://ollama.com/signup,tld-plus-one,Glenda_Brewer,)Kxb5!Vp85,,ollama.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Email address"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""claudia22@example.com"",
+      ""AutofillWeb_Selector"": ""#email""
+    }
+  ]
+}"
+https://www.freelancer.com/signup,tld-plus-one,claudia22@example.com,N%*8Ww(OIN,,freelancer.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""First Name"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""John"",
+      ""AutofillWeb_Selector"": "".ng-tns-c2763164415-4 .NativeElement""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Last Name"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""Doe"",
+      ""AutofillWeb_Selector"": "".ng-tns-c2763164415-5 .NativeElement""
+    }
+  ]
+}"
+https://www.nassna.com/app/Identity/Account/Login,tld-plus-one,qwilson@example.net,80EMDga7(x,,nassna.com,,,,,"{
+  ""Custom"": [
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Remember me?"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""✓"",
+      ""AutofillWeb_Selector"": ""#Input_RememberMe""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Phone"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""01234567890"",
+      ""AutofillWeb_Selector"": ""#Input_PhoneNumber""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Confirm Password"",
+      ""AutofillWeb_Type"": ""password"",
+      ""AutofillWeb"": ""+Js#evql+8"",
+      ""AutofillWeb_Selector"": ""#Input_ConfirmPassword""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""First Name"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""Kelsey"",
+      ""AutofillWeb_Selector"": ""#Input_FirstName""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Last Name"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""Marks"",
+      ""AutofillWeb_Selector"": ""#Input_LastName""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""City"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""Paris"",
+      ""AutofillWeb_Selector"": ""#Input_City""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Country"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""FR"",
+      ""AutofillWeb_Selector"": ""#Input_Country""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Gender"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""M"",
+      ""AutofillWeb_Selector"": ""#Input_gender""
+    },
+    {
+      ""Type"": ""AutofillWeb"",
+      ""AutofillWeb_Title"": ""Address"",
+      ""AutofillWeb_Type"": ""text"",
+      ""AutofillWeb"": ""Unit 7429 Box 0349 DPO AE 45359"",
+      ""AutofillWeb_Selector"": ""#Input_Address1""
+    }
+  ]
+}"

--- a/tests/assets/references/synology-c2.yml
+++ b/tests/assets/references/synology-c2.yml
@@ -1,0 +1,137 @@
+---
+#
+# Reference data for Snyology C2 Password with custom fields (--all).
+#
+
+- login: claudia22@example.com
+  password: zVhw534B6HQy
+  title: obsidian.md
+  url: https://obsidian.md/account/
+
+- login: vsmith@example.com
+  password: Mci^A7*gUw6qMp
+  title: client.googiehost.com
+  url: https://client.googiehost.com/cart.php?a=checkout&e=false
+
+- login: MichaelWhite
+  otpauth: otpauth://totp/GitHub:MichaelWhite?secret=9CZBZAOFRM&issuer=GitHub
+  password: 9rXQ4Xyl^7
+  title: github.com
+  url: https://github.com
+
+- Captcha Security Check: deathdonna
+  Confirm Password: '#x5JMrV^7+'
+  Email Address (Recommended): vsmith@example.com
+  login: HollyHowell
+  password: '#x5JMrV^7+'
+  title: wikipedia.org
+  url: https://en.wikipedia.org/w/index.php
+
+- login: vsmith@example.com
+  password: RAYb0h4idYOCLpL2
+  title: my.anydesk.com
+  url: https://my.anydesk.com/auth/realms/myanydesk/protocol/openid-connect/auth?client_id=myanydesk-frontend&code_challenge=G380ldjh0ubWB6JBYdgyw8uoLyzcIiVrP8ROOBdyin0ZT&code_challenge_method=S256&kc_idp_hint=custom-idp&redirect_uri=https%3A%2F%2Fmy.anydesk.com%2Fv2%2F&response_mode=fragment&response_type=code&scope=openid&state=c27cd912-3334-465e-91be-71ba776eea64&ui_locales=en
+
+- login: 01234567890
+  password: $ri3sPuLw4
+  title: android://iQcLnIDl0CGP7IFOyNzMVJOH-vdIhdpXQeivuFwnPTwzZxhGNycafCfQkV8AqCwwNnMKdE3Yb9upiC2MlkcDfA==@com.facebook.katana/
+  url: android://iQcLnIDl0CGP7IFOyNzMVJOH-vdIhdpXQeivuFwnPTwzZxhGNycafCfQkV8AqCwwNnMKdE3Yb9upiC2MlkcDfA==@com.facebook.katana/
+
+- Password: '&x35h@Fz6I'
+  Text: JohnLucero
+  login: claudia22@example.com
+  password: '&x35h@Fz6I'
+  title: codeforces.com
+  url: https://codeforces.com/register
+
+- Password: )5R+Tw)Nx8
+  login: claudia22@example.com
+  password: )5R+Tw)Nx8
+  title: proton.me
+  url: https://account.proton.me/pass/signup
+
+- 'Server:': sql.freedb.tech
+  login: freedb_John
+  password: M!JPQbyJ@4
+  title: https://phpmyadmin.freedb.tech
+  url: https://phpmyadmin.freedb.tech
+
+- Full Name: Heather Costa
+  login: vsmith@example.com
+  password: 2_2I8EnO67
+  title: scribehow.com
+  url: https://scribehow.com/signup
+
+- login: محمد_عبد_الشكور
+  password: $)_nAMxh!9
+  title: tybaa.com
+  url: https://www.tybaa.com
+
+- Email: claudia22@example.com
+  login: SusanGillespie
+  password: '*G3#HVArU!'
+  title: archlinux.org
+  url: archlinux.org
+
+- Enter A New Password: g^k_9J7oKT
+  password: g^k_9J7oKT
+  title: x.com
+  url: https://x.com/i/flow/password_reset
+
+- login: claudia22@example.com
+  password: Qae.=`0z''hG*FK{4W!8:s,G"
+  title: 127.0.0.1:65000
+  url: http://127.0.0.1:65000/web/register
+
+- login: vsmith@example.com
+  password: ^lBb)!&dA9
+  title: account.postmarkapp.com
+  url: https://account.postmarkapp.com/sign_up
+
+- login: claudia22@example.com
+  password: da2eTfLqB%
+  title: clickup.com
+  url: https://app.clickup.com/
+
+- login: claudia22@example.com
+  otpauth: otpauth://totp/OpenAI%3Aqmorrison%40example.org?secret=Z7oWE5HLuWARlRQ4p5ABkN8M86iNcwIC&issuer=OpenAI
+  password: =#FhcshvymJ6Dc5
+  title: auth0.openai.com
+  url: 'https://auth0.openai.com
+
+    https://chatgpt.com'
+
+- Choose Password: pUZ(4Xhzl9
+  Email (Optional): iramirez@example.com
+  Enter Captcha: X6cmY
+  login: Cindy_Johnson
+  password: T!JUAWjg(7
+  title: windscribe.com
+  url: https://windscribe.com/signup
+
+- Email Address: claudia22@example.com
+  login: Glenda_Brewer
+  password: )Kxb5!Vp85
+  title: ollama.com
+  url: https://ollama.com/signup
+
+- First Name: John
+  Last Name: Doe
+  login: claudia22@example.com
+  password: N%*8Ww(OIN
+  title: freelancer.com
+  url: https://www.freelancer.com/signup
+
+- Address: Unit 7429 Box 0349 DPO AE 45359
+  City: Paris
+  Confirm Password: +Js#evql+8
+  Country: FR
+  First Name: Kelsey
+  Gender: M
+  Last Name: Marks
+  Phone: 01234567890
+  Remember Me?: ✓
+  login: qwilson@example.net
+  password: 80EMDga7(x
+  title: nassna.com
+  url: https://www.nassna.com/app/Identity/Account/Login

--- a/tests/imports/test_parse.py
+++ b/tests/imports/test_parse.py
@@ -16,6 +16,7 @@ REFERENCE_OTHER = tests.yaml_load('keepass-other.yml')
 REFERENCE_KDBX = tests.yaml_load('keepass-kdbx.yml')
 REFERENCE_REVELATION = tests.yaml_load('revelation-other.yml')
 REFERENCE_BITWARDEN = tests.yaml_load('bitwarden-other.yml')
+REFERENCE_C2 = tests.yaml_load('synology-c2.yml')
 
 
 class TestParse(tests.Test):
@@ -221,3 +222,27 @@ class TestParse(tests.Test):
         with tests.cls('BitwardenJSON', prefix) as importer:
             importer.parse()
             self.assertImport(importer.data, REFERENCE_BITWARDEN, keep)
+
+    def test_importers_synology(self):
+        """Testing: parse method for Synology C2 Password with custom fields."""
+        keep = [
+            'title', 'password', 'login', 'url', 'comments', 'otpauth',
+            'Captcha Security Check', 'Confirm Password',
+            'Email Address (Recommended)', 'Password', 'Text',
+            'Server:', 'Full Name', 'Email', 'Enter A New Password',
+            'Choose Password', 'Email (Optional)', 'Enter Captcha',
+            'Email Address', 'First Name', 'Last Name',
+            'Address', 'City', 'Country', 'Gender', 'Phone', 'Remember Me?',
+        ]
+        prefix = os.path.join(tests.db, 'c2password.csv')
+        with tests.cls('SynologyC2CSV', prefix) as importer:
+            importer.parse()
+            self.assertImport(importer.data, REFERENCE_C2, keep)
+
+    def test_import_synology_malformed_json(self):
+        """Testing: Synology C2 Password raises FormatError on bad JSON."""
+        from pass_import.errors import FormatError
+        prefix = os.path.join(tests.db, 'c2password-malformed.csv')
+        with self.assertRaises(FormatError):
+            with tests.cls('SynologyC2CSV', prefix) as importer:
+                importer.parse()


### PR DESCRIPTION
Synology C2 Password stores custom fields (registration fields, autofill hints, free-text notes) as JSON in the `Others` column.
The base CSV parser discards these, causing custom fields to be silently skipped during import with `--all`.

- add `parse()` override for `SynologyC2CSV` class
- extract `Text` and `AutofillWeb` custom entries from `Others` JSON
- raise `FormatError` on malformed JSON
- fix `self.data` type annotation (`Dict` -> `List[Dict]`)
- add test data (`c2password.csv`) with custom fields and edge cases
- add `FormatError` coverage (`c2password-malformed.csv`)
- add `test_importers_synology` and `test_import_synology_malformed_json`

Backward compatible: entries with no `Others` value or an empty one produce the same output as before.
Existing `synology.csv` / `main.yml` tests pass unchanged.